### PR TITLE
Fix and upgrade of port:kf5-okular(-devel)

### DIFF
--- a/devel/git/Portfile
+++ b/devel/git/Portfile
@@ -72,7 +72,7 @@ if {[variant_isset pcre]} {
     }
 }
 
-pre-build
+pre-build {
     build.args      CFLAGS="${CFLAGS}" \
                     LDFLAGS="${LDFLAGS}" \
                     CC=${configure.cc} \

--- a/kf5/kf5-okular/Portfile
+++ b/kf5/kf5-okular/Portfile
@@ -79,7 +79,8 @@ patchfiles-append   patch-utilcpp.diff \
                     patch-frameworks.diff \
                     patch-kcfg_name.diff \
                     patch-use-kate5.diff \
-                    patch-open-docs-from-Finder.diff
+                    patch-open-docs-from-Finder.diff \
+                    patch-generators-cmake.diff
 
 # https://bugs.kde.org/show_bug.cgi?id=368382
 patchfiles-append   patch-plugin-depends.diff

--- a/kf5/kf5-okular/Portfile
+++ b/kf5/kf5-okular/Portfile
@@ -28,12 +28,10 @@ subport ${name}-devel {
 if {${subport} eq "${name}-devel"} {
     conflicts       ${name}
     fetch.type      git
-    git.url     git://anongit.kde.org/okular
-# #     v16.12.0-46-g73f7cd6
-#     git.branch      73f7cd627bc97393b99416bcea1a5cf7b9583b9c
-    # v17.04.1-24-gc1e60e5
-    git.branch      c1e60e5539a4e2776bb97ad3d6e4e311cc904730
-    version         17.04.1.24
+    git.url         git://anongit.kde.org/okular
+    # v17.12.1-47-ge043d51
+    git.branch      e043d517c5d12a3e2d2a21194116437a59031377
+    version         17.12.1.47
     worksrcdir      ${kf5.project}-5
     distname        ${kf5.project}-5
     set SPECPPATH   devel/
@@ -75,12 +73,16 @@ platform darwin {
 kf5.allow_apidocs_generation no
 
 patch.pre_args      -Np1
+if {${subport} eq "${name}-devel"} {
+    patchfiles-append   patch-frameworks-devel.diff
+} else {
+    patchfiles-append   patch-frameworks.diff \
+                        patch-generators-cmake.diff
+}
 patchfiles-append   patch-utilcpp.diff \
-                    patch-frameworks.diff \
                     patch-kcfg_name.diff \
                     patch-use-kate5.diff \
-                    patch-open-docs-from-Finder.diff \
-                    patch-generators-cmake.diff
+                    patch-open-docs-from-Finder.diff
 
 # https://bugs.kde.org/show_bug.cgi?id=368382
 patchfiles-append   patch-plugin-depends.diff

--- a/kf5/kf5-okular/files/patch-frameworks-devel.diff
+++ b/kf5/kf5-okular/files/patch-frameworks-devel.diff
@@ -1,0 +1,22 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d76f67e0c..80fb7d204 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -216,7 +216,7 @@ generate_export_header(okularcore BASE_NAME okularcore EXPORT_FILE_NAME "${CMAKE
+ 
+ # Special handling for linking okularcore on OSX/Apple
+ IF(APPLE)
+-    SET(OKULAR_IOKIT "-framework IOKit" CACHE STRING "Apple IOKit framework")
++    SET(OKULAR_APPLE_FRAMEWORKS "-framework IOKit -framework CoreFoundation -framework CoreGraphics" CACHE STRING "required Apple frameworks")
+ ENDIF(APPLE)
+ 
+ # Extra library needed by imported synctex code on Windows
+@@ -226,7 +226,7 @@ endif(WIN32)
+ 
+ target_link_libraries(okularcore
+ PRIVATE
+-    ${OKULAR_IOKIT}
++    ${OKULAR_APPLE_FRAMEWORKS}
+     ${SHLWAPI}
+     KF5::Archive
+     KF5::JS

--- a/kf5/kf5-okular/files/patch-generators-cmake.diff
+++ b/kf5/kf5-okular/files/patch-generators-cmake.diff
@@ -1,0 +1,11 @@
+--- a/generators/spectre/CMakeLists.txt
++++ b/generators/spectre/CMakeLists.txt
+@@ -21,7 +21,7 @@ ki18n_wrap_ui(okularGenerator_ghostview_SRCS
+ kconfig_add_kcfg_files(okularGenerator_ghostview_SRCS conf/gssettings.kcfgc )
+ 
+ 
+-okular_add_generator(okularGenerator_ghostview MODULE ${okularGenerator_ghostview_SRCS})
++okular_add_generator(okularGenerator_ghostview ${okularGenerator_ghostview_SRCS})
+ 
+ target_link_libraries(okularGenerator_ghostview okularcore ${LIBSPECTRE_LIBRARY} KF5::I18n Qt5::Xml)
+ 


### PR DESCRIPTION
Both port:kf5-okular and port:kf5-okular-devel (now at 17.12.1) work now. In-app icons are missing though.