### PR TITLE
VLC-test: properly build VLC.app

### DIFF
--- a/multimedia/VLC-test/Portfile
+++ b/multimedia/VLC-test/Portfile
@@ -9,7 +9,7 @@ if {[file exists ${filespath}/../../../_resources/port1.0/group/locale_select-1.
     PortGroup       locale_select 1.0
 }
 
-name                 VLC-test
+name                VLC-test
 
 categories          multimedia devel
 maintainers         gmail.com:rjvbertin openmaintainer
@@ -53,7 +53,8 @@ distname            vlc-${version}
 use_xz              yes
 
 checksums           rmd160  ae2f84495ae337200fe6167274475c75cf1346af \
-                    sha256  01f3db3790714038c01f5e23c709e31ecd6f1c046ac93d19e1dde38b3fc05a9e
+                    sha256  01f3db3790714038c01f5e23c709e31ecd6f1c046ac93d19e1dde38b3fc05a9e \
+                    size    24934112 \
 
 platform darwin {
     # Enable HFS compression of the workdir if the compress_workdir PortGroup is installed
@@ -217,7 +218,17 @@ configure.cppflags-append -D__unix__=1 -Wno-unknown-pragmas
 configure.cppflags-append -I${prefix}/lib/live/liveMedia/include
 
 build.target        all
-destroot.target     install
+
+if {${subport} ne "lib${name}"} {
+    # The VLC.app target does not obey DESTDIR and tries to copy a
+    # non-existing folder. The folder is only used by the spatialaudio
+    # plugin which we don't include in our build.
+    destroot.destdir    prefix=${destroot}${prefix}
+    destroot.target     VLC.app
+    patchfiles-append   patch-no-hrtfs.diff
+} else {
+    destroot.target     install
+}
 
 livecheck.url       http://download.videolan.org/pub/videolan/vlc/
 livecheck.regex     <a href=\"(\\d\[\\d|\.|\\w\]+).*/\">

--- a/multimedia/VLC-test/files/patch-no-hrtfs.diff
+++ b/multimedia/VLC-test/files/patch-no-hrtfs.diff
@@ -1,0 +1,11 @@
+--- extras/package/macosx/package.mak	2018-10-08 13:49:27.000000000 +0200
++++ extras/package/macosx/package.mak	2018-10-08 13:49:40.000000000 +0200
+@@ -36,8 +36,6 @@
+ 	cp -r "$(prefix)/share/vlc/lua" $@/Contents/MacOS/share/
+ 	cp -r "$(prefix)/lib/vlc/lua" $@/Contents/MacOS/share/
+ endif
+-	## HRTFs
+-	cp -r $(srcdir)/share/hrtfs $@/Contents/MacOS/share/
+ 	## Copy some other stuff (?)
+ 	mkdir -p $@/Contents/MacOS/include/
+ 	(cd "$(prefix)/include" && $(AMTAR) -c --exclude "plugins" vlc) | $(AMTAR) -x -C $@/Contents/MacOS/include/


### PR DESCRIPTION
This change adresses three issues leading to a failure during built of VLC.app:

1. The make target in destroot needs to be VLC.app.
2. The VLC.app target does not obey the DESTROOT variable. To work around this, we need to set destroot.destdir.
3. The tarball is missing the folder share/hrtfs. It is present in the github tree though, so we can fetch is from there.

Fixes #16

Regarding no. 3: This issue was mentioned at https://forum.videolan.org/viewtopic.php?t=141470#p464626 and should have been fixed. Probably we need to file a bugreport upstream about that. For the time being, I don't know how important this file is and if it's worth the effort of pulling it from github. We may also try to delete the corresponding line from the Makefile.

I guess the code for copying the file to its correct place would be better suited for a post-extract section. Also we may use xinstall. So this PR is probably not ready to be merged. However, I wanted to get some feedback before continuing.