### PR TITLE
port:VLC : upgrade to 3.0.6 and fix build against libvpx 1.8.0

### DIFF
--- a/multimedia/VLC/Portfile
+++ b/multimedia/VLC/Portfile
@@ -58,7 +58,7 @@ if {${subport} eq "VLC-test" || ${subport} eq "libVLC-test"} {
 universal_variant   no
 supported_archs     x86_64
 
-version             3.0.4
+version             3.0.6
 license             GPL-2
 
 platforms           darwin
@@ -68,9 +68,9 @@ dist_subdir         VLC
 distname            vlc-${version}
 use_xz              yes
 
-checksums           rmd160  ae2f84495ae337200fe6167274475c75cf1346af \
-                    sha256  01f3db3790714038c01f5e23c709e31ecd6f1c046ac93d19e1dde38b3fc05a9e
-#                     size    24934112
+checksums           rmd160  717f81c5ab63d7d5cdb427a198d958e0e418609f \
+                    sha256  18c16d4be0f34861d0aa51fbd274fb87f0cab3b7119757ead93f3db3a1f27ed3
+#                     size    25699704
 
 platform darwin {
     # Enable HFS compression of the workdir if the compress_workdir PortGroup is installed

--- a/multimedia/VLC/Portfile
+++ b/multimedia/VLC/Portfile
@@ -438,7 +438,8 @@ if {${subport} ne "lib${name}"} {
         description {Enable all variants except x11 (and except freerdp, currently)} {}
 }
 
-patchfiles-append           patch-for-lua53.diff
+patchfiles-append           patch-for-lua53.diff \
+                            patch-for-libvpx-1.8.0.diff
 
 platform darwin {
     default_variants-append +quartz

--- a/multimedia/VLC/files/patch-for-libvpx-1.8.0.diff
+++ b/multimedia/VLC/files/patch-for-libvpx-1.8.0.diff
@@ -1,0 +1,32 @@
+From 5575fe3eb3fd46bada8662268b74d03493476a84 Mon Sep 17 00:00:00 2001
+From: Danny Milosavljevic <dannym@scratchpost.org>
+Date: Mon, 11 Feb 2019 16:07:12 +0100
+Subject: [PATCH] codec: vpx: Detect libvpx 1.8.0 and, if detected, use fewer
+ frame formats in the chroma_table
+
+Signed-off-by: Steve Lhomme <robux4@ycbcr.xyz>
+---
+ modules/codec/vpx.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git modules/codec/vpx.c modules/codec/vpx.c
+index f03c7fae625..59b3acdef74 100644
+--- modules/codec/vpx.c
++++ modules/codec/vpx.c
+@@ -117,6 +117,7 @@ static const struct
+     { VLC_CODEC_I440, VPX_IMG_FMT_I440, 8, 0 },
+ 
+     { VLC_CODEC_YV12, VPX_IMG_FMT_YV12, 8, 0 },
++#if VPX_IMAGE_ABI_VERSION < 5
+     { VLC_CODEC_YUVA, VPX_IMG_FMT_444A, 8, 0 },
+     { VLC_CODEC_YUYV, VPX_IMG_FMT_YUY2, 8, 0 },
+     { VLC_CODEC_UYVY, VPX_IMG_FMT_UYVY, 8, 0 },
+@@ -129,7 +130,7 @@ static const struct
+ 
+     { VLC_CODEC_ARGB, VPX_IMG_FMT_ARGB, 8, 0 },
+     { VLC_CODEC_BGRA, VPX_IMG_FMT_ARGB_LE, 8, 0 },
+-
++#endif
+     { VLC_CODEC_GBR_PLANAR, VPX_IMG_FMT_I444, 8, 1 },
+     { VLC_CODEC_GBR_PLANAR_10L, VPX_IMG_FMT_I44416, 10, 1 },
+ 


### PR DESCRIPTION
Tested on Mojave with +quartz.