### PR TITLE
port:lmdbxx : fix checksums and worksrcdir

### DIFF
--- a/databases/lmdbxx/Portfile
+++ b/databases/lmdbxx/Portfile
@@ -18,10 +18,12 @@ long_description    This is a comprehensive C++ wrapper for the LMDB embedded   
                     interface and an object-oriented resource interface with RAII \
                     semantics.
 
-checksums           rmd160  68c36abcb3adb9fa50d0509c8c06e25a81cdb3d9 \
-                    sha256  a7958341d13280ca8400263e8373da50116e806c6ad4e9fa4beca82d9629df8c
+checksums           rmd160  e8fd89b5aa9f4629ce95a02fc40b836f7973503a \
+                    sha256  a32053edc869646c8e8fe55a053d84ab96a73c5ce7cfb9636ed82e561e6bbe13
 
 depends_run         port:lmdb
+
+worksrcdir          drycpp-lmdbxx-0b43ca8
 
 use_configure       no
 


### PR DESCRIPTION
Was trying to install `kf5-kdevelop` (is this the right one?) and I had this issue. This makes it get a little further (the `kf5-kdevelop` package fails due to patching errors).