### PR TITLE
port:meson : mesonlib.darwin_get_object_archs only accepts str type

### DIFF
--- a/devel/meson/Portfile
+++ b/devel/meson/Portfile
@@ -25,6 +25,9 @@ checksums           rmd160  d9faccb65234923fdf480452404bd7d1e43c7d5b \
                     sha256  f27b7a60f339ba66fe4b8f81f0d1072e090a08eabbd6aa287683b2c2b9dd2d82
 #                     size    1451189
 
+patchfiles          posixpath-str.patch
+patch.pre_args      -p1
+
 # as of version 0.45.0,requires python 3.5 or better
 
 set python_versions     {35 36 37}

--- a/devel/meson/files/posixpath-str.patch
+++ b/devel/meson/files/posixpath-str.patch
@@ -1,0 +1,12 @@
+diff -urN meson-0.51.1-orig/mesonbuild/compilers/clike.py meson-0.51.1/mesonbuild/compilers/clike.py
+--- meson-0.51.1-orig/mesonbuild/compilers/clike.py	2019-08-12 01:17:05.000000000 -0400
++++ meson-0.51.1/mesonbuild/compilers/clike.py	2019-08-12 01:19:02.000000000 -0400
+@@ -991,7 +991,7 @@
+         for f in files:
+             if not f.is_file():
+                 continue
+-            archs = mesonlib.darwin_get_object_archs(f)
++            archs = mesonlib.darwin_get_object_archs(str(f))
+             if archs and env.machines.host.cpu_family in archs:
+                 return f
+             else:


### PR DESCRIPTION
Related to #52. `mesonlib.darwin_get_object_archs` only accepts `str` and does not convert `Path` objects automatically.