### PR TITLE
port:quassel : remove QtWebKit support; allow building without QtWebEngine

### DIFF
--- a/irc/quassel/Portfile
+++ b/irc/quassel/Portfile
@@ -12,7 +12,7 @@ github.setup    quassel quassel 0.13.1
 # so we drop the variant until all that's sorted out. For a KF5 IRC client
 # see port:kf5-konversation .
 variant kde description {include KDE support; not currently supported with Qt5/KF5} {}
-variant qtwebkit description {use the legacy QtWebKit for HTML rendering} {}
+variant qtwebengine description {use QtWebEngine for HTML rendering} {}
 
 if {![variant_exists kde] || ![variant_isset kde]} {
     PortGroup qt5   1.0
@@ -43,15 +43,12 @@ platform darwin {
 
 qt5.depends_component \
                 qtmultimedia
-if {[variant_isset qtwebkit]} {
-    qt5.depends_component \
-                qtwebkit
-    configure.args-append \
-                -DWITH_WEBKIT=ON \
-                -DWITH_WEBENGINE=OFF
-} else {
+if {[variant_isset qtwebengine]} {
     qt5.depends_component \
                 qtwebengine
+    configure.args-append \
+                -DWITH_WEBKIT=OFF \
+                -DWITH_WEBENGINE=ON
 }
 qt5.depends_build_component \
                 qttools


### PR DESCRIPTION
QtWebKit is deprecated so the option is removed.

The QtWebEngine package is prone to frustrating failures to build especially if they have been compiling for a while. This change makes Quassel get built without it by default.