### PR TITLE
calligra: fix some configure-stage errors

### DIFF
--- a/kde/calligra/Portfile
+++ b/kde/calligra/Portfile
@@ -104,7 +104,7 @@ depends_lib-append  port:kdelibs4 path:lib/libakonadi-contact.4.dylib:kdepimlibs
                     port:librevenge port:libodfgen port:libwpd-0.10 port:libwpg-0.3 port:libwps-0.3 port:libetonyek \
                     port:kde4-runtime port:kde4-baseapps port:okular \
                     port:libvisio-0.1 port:libgit2 port:openjpeg15 port:Vc \
-                    port:lcms2 port:libpng port:eigen3 port:exiv2 port:boost port:gsl \
+                    port:lcms2 port:libpng path:share/pkgconfig/eigen3.pc:eigen3 port:exiv2 port:boost port:gsl \
                     port:poppler-qt4-mac port:fftw-3 port:openexr port:tiff path:include/turbojpeg.h:libjpeg-turbo \
                     port:libiconv port:libkdcraw port:pstoedit port:glew port:marble
 

--- a/kde/calligra/Portfile
+++ b/kde/calligra/Portfile
@@ -79,6 +79,9 @@ if {${subport} eq "${name}"} {
     } else {
         extract.post_args-append    "-k"
     }
+    # message called with incorrect number of arguments
+    patchfiles-append \
+                    patch-fix-pigment-CMakeLists.diff
     configure.args-append \
                     -DKDE4_BUILD_TESTS:BOOL=OFF
 } else {

--- a/kde/calligra/files/patch-fix-pigment-CMakeLists.diff
+++ b/kde/calligra/files/patch-fix-pigment-CMakeLists.diff
@@ -1,0 +1,11 @@
+--- libs/pigment/CMakeLists.txt
++++ libs/pigment/CMakeLists.txt	2024-08-31 00:54:24.000000000 +0800
+@@ -26,7 +26,7 @@
+     ko_compile_for_all_implementations_no_scalar(__per_arch_factory_objs compositeops/KoOptimizedCompositeOpFactoryPerArch.cpp)
+ 
+     message("Following objects are generated from the per-arch lib")
+-    message(${__per_arch_factory_objs})
++    message("${__per_arch_factory_objs}")
+ endif()
+ 
+ add_subdirectory(tests)


### PR DESCRIPTION
It still fails to find some ports (`OpenEXR`, `poppler-qt4-mac`, `postgresql`), but at least with this configure succeeds.