### PR TITLE
libwps-0.3: depend on boost to fix build

### DIFF
--- a/textproc/libwps-0.3/Portfile
+++ b/textproc/libwps-0.3/Portfile
@@ -27,7 +27,10 @@ checksums           rmd160  d803fe0f244961ff0ee801192fa6afa6a1261aa2 \
 
 depends_build       port:pkgconfig
 
-depends_lib         port:librevenge
+# checking for boost shared ptr... no
+# configure: error: Could not find Boost implementation of shared_ptr
+depends_lib         port:boost \
+                    port:librevenge
 
 configure.args      --disable-werror \
                     --without-docs


### PR DESCRIPTION
(I have used `boost` PG myself, but apparently here it is preferred to use `boost` port, so I added that instead.)