### PR TITLE
kate: add gcc-4.0 to blacklist

### DIFF
--- a/kde/kate/Portfile
+++ b/kde/kate/Portfile
@@ -37,8 +37,9 @@ patchfiles          patch-Zoom.diff \
                     patch-no-pate.diff \
                     patch-open-docs-from-finder.diff
 
-#Blacklist gcc42 and llvm-gcc-42 (does not build with gcc, ticket #37596)
-compiler.blacklist  gcc-4.2 apple-gcc-4.2 llvm-gcc-4.2 macports-llvm-gcc-4.2
+# Blacklist gcc42 and llvm-gcc-42 (does not build with gcc, ticket #37596)
+# Also blacklist gcc40: kateviinputmodemanager.cpp: error: ambiguous overload for ‘operator+’ in ‘markerChar + ":"’
+compiler.blacklist  *gcc-4.0 *gcc-4.2
 
 configure.args-append \
                     -DCMAKE_DISABLE_FIND_PACKAGE_KActivities=ON


### PR DESCRIPTION
To my surprise, it began compiling with gcc-4.0, and of course failed :) 