### PR TITLE
qt4-mac-devel: fix a bug in qmake generator patch, fixes ppc64 build

### DIFF
--- a/aqua/qt4-mac-devel/files/patch-qmake_generators_unix_unixmake.cpp.fix_arch.diff
+++ b/aqua/qt4-mac-devel/files/patch-qmake_generators_unix_unixmake.cpp.fix_arch.diff
@@ -46,7 +46,7 @@
 +                      }
 +                      QString t_arch = l.at(lit).trimmed().toLower();
 +                      // make sure next option is valid
-+                      const QString archs[] = { "i386", "x86_64", "ppc", "ppc64", QString() };
++                      const QString archs[] = { "i386", "x86_64", "ppc64", "ppc", QString() };
 +                      int i = 0;
 +                      for(; !archs[i].isNull(); ++i) {
 +                        if (t_arch.startsWith(archs[i])) {


### PR DESCRIPTION
@RJVB I guess no one ever tried to build it for ppc64 since this patch was introduced LOL
